### PR TITLE
Add interface statistics (netstat -ibd)

### DIFF
--- a/defs.pxd
+++ b/defs.pxd
@@ -290,6 +290,7 @@ cdef extern from "net/if.h":
         uint64_t ifi_imcasts
         uint64_t ifi_omcasts
         uint64_t ifi_iqdrops
+        uint64_t ifi_oqdrops
         uint64_t ifi_noproto
         uint64_t ifi_hwassist
         time_t ifi_epoch


### PR DESCRIPTION
This PR adds stats per address/per interface essentially copying 'netstat -ibd' behaviour.