### PR TITLE
new interface type IFT_WIREGUARD

### DIFF
--- a/defs.pxd
+++ b/defs.pxd
@@ -1072,6 +1072,7 @@ cdef extern from "net/if_types.h":
         IFT_ENC
         IFT_PFLOG
         IFT_PFSYNC
+        IFT_WIREGUARD
 
 
 cdef extern from "unistd.h":


### PR DESCRIPTION
Wireguard kernel driver added a new interface type. Without this, we're crashing on HA systems that have TrueCommand configured (it uses wireguard).
```
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/network.py", line 545, in query
    for name, iface in netif.list_interfaces().items():
  File "netif.pyx", line 2118, in netif.list_interfaces
  File "netif.pyx", line 2072, in netif.list_interfaces_internal
  File "/usr/local/lib/python3.9/enum.py", line 384, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.9/enum.py", line 702, in __new__
    raise ve_exc
ValueError: 248 is not a valid InterfaceType